### PR TITLE
Staging sparc api

### DIFF
--- a/app/bfworker.py
+++ b/app/bfworker.py
@@ -1,0 +1,69 @@
+from pennsieve import Pennsieve
+import pennsieve
+from app.config import Config
+
+class BFWorker(object):
+  def __init__(self, id):
+    self.bf = Pennsieve(api_token=Config.PENNSIEVE_API_TOKEN, api_secret=Config.PENNSIEVE_API_SECRET)
+
+
+  def getCollectionAndMetaFromPackageId(self, packageId):
+    pkg = self.bf.get(packageId)
+    if type(pkg) is pennsieve.DataPackage:
+      colId = pkg.parent
+      col = self.bf.get(colId)
+      items = col.items
+      for item in items:
+        if packageId == item.id:
+          return [colId, item.name]
+    return None
+
+  def getURLFromCollectionIdAndFileName(self, collectionId, fileName):
+    col = self.bf.get(collectionId)
+    if type(col) is pennsieve.Collection:
+      items = col.items
+      for item in items:
+        if fileName == item.name:
+          pkg = item
+          try:
+            bfFile = pkg.files[0]
+            url = bfFile.url
+            return url
+          except:
+            return None
+    return None
+
+  def getUrlfromPackageId(self, packageId):
+    pId = packageId
+    if ('N:' not in packageId):
+      pId = 'N:' + packageId
+    pk = self.bf.get(pId)
+    return pk.files[0].url
+
+  def getImagefromPackageId(self, packageId):
+    pId = packageId
+    if ('N:' not in packageId):
+      pId = 'N:' + packageId
+    pk = self.bf.get(pId)
+    # resp = requests.get(pk.files[0].url)
+    return pk.files[0].url if pk is not None else ''
+
+  def getURLFromDatasetIdAndFilePath(self, datasetId, filePath):
+      fileArray = filePath.split('/')
+      items = self.bf.get_dataset(datasetId).items
+      count = 0
+      while type(items) is list:
+          item = items[count]
+          for fileName in fileArray:
+              if fileName == item.name:
+                  if type(item) is pennsieve.Collection:
+                      items = item.items
+                      count = 0
+                      continue
+                  else:
+                      try:
+                          return item.files[0].url
+                      except:
+                          return None
+          count += 1
+      return None

--- a/app/config.py
+++ b/app/config.py
@@ -30,7 +30,7 @@ class Config(object):
     KNOWLEDGEBASE_KEY = os.environ.get("KNOWLEDGEBASE_KEY", "secret-key")
     DEPLOY_ENV = os.environ.get("DEPLOY_ENV", "development")
     SPARC_APP_HOST = os.environ.get("SPARC_APP_HOST", "https://sparc-app.herokuapp.com")
-    SCI_CRUNCH_HOST = os.environ.get("SCICRUNCH_HOST", "https://scicrunch.org/api/1/elastic/SPARC_PortalDatasets_pr")
+    SCI_CRUNCH_HOST = os.environ.get("SCICRUNCH_HOST", "https://scicrunch.org/api/1/elastic/SPARC_PortalDatasets_stage")
     MAPSTATE_TABLENAME = os.environ.get("MAPSTATE_TABLENAME", "mapstates")
     SCAFFOLDSTATE_TABLENAME = os.environ.get("SCAFFOLDSTATE_TABLENAME", "scaffoldstates")
     WRIKE_TOKEN = os.environ.get("WRIKE_TOKEN")

--- a/app/scicrunch_process_results.py
+++ b/app/scicrunch_process_results.py
@@ -1,7 +1,7 @@
 import importlib
 import json
 import re
-
+from flask import jsonify
 
 # process_kb_results: Loop through SciCrunch results pulling out desired attributes and processing DOIs and CSV files
 def _prepare_results(results):
@@ -21,6 +21,12 @@ def _prepare_results(results):
         attr = _transform_attributes(attributes_map, hit)
         attr['doi'] = _convert_doi_to_url(attr['doi'])
         attr['took'] = results['took']
+        # find context files by looking through object mimetypes
+        attr['abi-contextual-information'] = [
+            file['dataset']['path']
+            for file in hit['_source']['objects']
+            if file['additional_mimetype']['name'].find('context') is not -1
+        ]
         try:
             attr['readme'] = hit['_source']['item']['readme']['description']
         except KeyError:
@@ -38,7 +44,7 @@ def _prepare_results(results):
 
 
 def process_results(results):
-    return json.dumps({'numberOfHits': results['hits']['total'], 'results': _prepare_results(results)})
+    return jsonify({'numberOfHits': results['hits']['total'], 'results': _prepare_results(results)})
 
 
 def reform_dataset_results(results):

--- a/app/scicrunch_process_results.py
+++ b/app/scicrunch_process_results.py
@@ -27,6 +27,10 @@ def _prepare_results(results):
             for file in hit['_source']['objects']
             if file['additional_mimetype']['name'].find('abi.context-information') is not -1
         ]
+        print([
+            file['additional_mimetype']['name']
+            for file in hit['_source']['objects']
+        ])
         try:
             attr['readme'] = hit['_source']['item']['readme']['description']
         except KeyError:

--- a/app/scicrunch_process_results.py
+++ b/app/scicrunch_process_results.py
@@ -25,7 +25,7 @@ def _prepare_results(results):
         attr['abi-contextual-information'] = [
             file['dataset']['path']
             for file in hit['_source']['objects']
-            if file['additional_mimetype']['name'].find('context') is not -1
+            if file['additional_mimetype']['name'].find('abi.context-information') is not -1
         ]
         try:
             attr['readme'] = hit['_source']['item']['readme']['description']

--- a/app/scicrunch_processing_common.py
+++ b/app/scicrunch_processing_common.py
@@ -13,6 +13,7 @@ SCAFFOLD_DIR = 'abi-scaffold-dir'
 SCAFFOLD_FILE = 'abi-scaffold-metadata-file'
 SCAFFOLD_THUMBNAIL = 'abi-scaffold-thumbnail'
 SCAFFOLD_VIEW_FILE = 'abi-scaffold-view-file'
+CONTEXT_FILE = 'abi-context-file'
 VIDEO = 'video'
 VERSION = 'version'
 README = 'readme'
@@ -32,6 +33,7 @@ MAPPED_MIME_TYPES = {
     'inode/vnd.abi.scaffold+thumbnail': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.thumbnail+file': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.view+file': SCAFFOLD_VIEW_FILE,
+    'application/x.abi.context-information+json': CONTEXT_FILE,
     'text/vnd.abi.plot+Tab-separated-values': PLOT_FILE,
     'text/vnd.abi.plot+csv': PLOT_FILE,
     'image/png': COMMON_IMAGES,

--- a/app/scicrunch_processing_common.py
+++ b/app/scicrunch_processing_common.py
@@ -33,7 +33,7 @@ MAPPED_MIME_TYPES = {
     'inode/vnd.abi.scaffold+thumbnail': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.thumbnail+file': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.view+file': SCAFFOLD_VIEW_FILE,
-    'application/vnd.abi.context-information+json': CONTEXT_FILE,
+    'application/x.vnd.abi.context-information+json': CONTEXT_FILE,
     'text/vnd.abi.plot+Tab-separated-values': PLOT_FILE,
     'text/vnd.abi.plot+csv': PLOT_FILE,
     'image/png': COMMON_IMAGES,

--- a/app/scicrunch_processing_common.py
+++ b/app/scicrunch_processing_common.py
@@ -33,7 +33,7 @@ MAPPED_MIME_TYPES = {
     'inode/vnd.abi.scaffold+thumbnail': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.thumbnail+file': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.view+file': SCAFFOLD_VIEW_FILE,
-    'application/x.abi.context-information+json': CONTEXT_FILE,
+    'application/vnd.abi.context-information+json': CONTEXT_FILE,
     'text/vnd.abi.plot+Tab-separated-values': PLOT_FILE,
     'text/vnd.abi.plot+csv': PLOT_FILE,
     'image/png': COMMON_IMAGES,

--- a/app/scicrunch_requests.py
+++ b/app/scicrunch_requests.py
@@ -1,3 +1,4 @@
+import json
 def create_query_string(query_string):
     return {
         "from": 0,
@@ -20,6 +21,14 @@ def create_doi_query(doi):
     }
 
 def create_multiple_doi_query(dois, size=10, from_=0):
+    print(json.dumps({
+        "size": 999,
+        "query": {
+            "terms": {
+                "item.curie": dois
+            }
+        }
+    }))
     return {
         "size": 999,
         "query": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,14 @@ def test_direct_download_url_small_file(client):
     assert r.status_code == 200
     assert b"proximal colon" in r.data
 
+def test_pennsieve_file_path_download(client):
+    colon_dataset_id = 76
+    colon_file_path = 'derivative%2Fscaffold_context_info.json'
+    r = client.get(f"/urlFromPennsieveDatasetIdAndFilePath/{colon_dataset_id}?filePath={colon_file_path}")
+    assert r.status_code == 200
+    assert 'url' in r.json
+
+
 
 def test_direct_download_url_thumbnail(client):
     small_s3_file = '95/1/files/derivative%2FScaffold%2Fthumbnail.png'

--- a/tests/test_scicrunch.py
+++ b/tests/test_scicrunch.py
@@ -424,3 +424,11 @@ def test_scaffold_files(client):
             key = f"{uri}files/{path}".replace('s3://pennsieve-prod-discover-publish-use1/', '')
             r = client.get(f"/s3-resource/{key}")
             assert r.status_code == 200
+
+def test_contextual_information(client):
+    r = client.get('/dataset_info/using_multiple_discoverIds/?discoverIds=76')
+    results = json.loads(r.data)
+    assert results['numberOfHits'] > 0
+    for item in results['results']:
+        if 'abi-contextual-information' in item:
+            assert r.status_code == 200

--- a/tests/test_scicrunch.py
+++ b/tests/test_scicrunch.py
@@ -425,10 +425,9 @@ def test_scaffold_files(client):
             r = client.get(f"/s3-resource/{key}")
             assert r.status_code == 200
 
-def test_contextual_information(client):
+def test_finding_contextual_information(client):
     r = client.get('/dataset_info/using_multiple_discoverIds/?discoverIds=76')
     results = json.loads(r.data)
-    assert results['numberOfHits'] > 0
+    assert results['numberOfHits'] > 0  # Test we could find the generic colon scaffold dataset
     for item in results['results']:
-        if 'abi-contextual-information' in item:
-            assert r.status_code == 200
+        assert len(item['abi-contextual-information']) > 0  # Check it has contextual information


### PR DESCRIPTION
# Description

This branch is used with `https://scicrunch.org/api/1/elastic/SPARC_PortalDatasets_stage`

It pulls files from the pennsieve python api as opposed to the discover s3 bucket.

When using this branch, calls on the front end using the `s3-resource/<path:path>` will be grabbed from the pennsieve python client.

Note that in order for this to work the `PENNSIEVE_API_SECRET` and `PENNSIEVE_API_TOKEN` keys *must* have access to the dataset of interest. This should not be an issue if the keys are a member of the [SPARC Data Curation Team](https://app.pennsieve.io/N:organization:618e8dd9-f8d2-4dc4-9abb-c6aaab2e78a0/teams/N:team:d296053d-91db-46ae-ac80-3c137ea144e4/) on pennsieve.




## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
